### PR TITLE
fix: Windows GCM이 GitHub 토큰을 무시하는 문제 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,10 +183,11 @@ pipeline {
                             bat "if exist \"${GITOPS_TMP_DIR}\" rmdir /s /q \"${GITOPS_TMP_DIR}\""
 
                             // gitops/deploy 브랜치가 있으면 clone, 없으면 main에서 새로 생성
+                            // credential.helper= : Windows GCM이 URL 토큰을 무시하는 것을 방지
                             script {
-                                def cloneResult = bat(script: "git clone --branch ${GITOPS_BRANCH} https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\"", returnStatus: true)
+                                def cloneResult = bat(script: "git -c credential.helper= clone --branch ${GITOPS_BRANCH} https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\"", returnStatus: true)
                                 if (cloneResult != 0) {
-                                    bat "git clone https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\""
+                                    bat "git -c credential.helper= clone https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\""
                                     dir("${GITOPS_TMP_DIR}") {
                                         bat "git checkout -b ${GITOPS_BRANCH}"
                                     }
@@ -209,11 +210,11 @@ pipeline {
                                 if (hasChanges != 0) {
                                     bat "git commit -m \"ci: update image tags to ${IMAGE_TAG} [ci skip]\""
                                     // pull은 원격 브랜치가 없을 수 있으므로 실패 허용
-                                    def pullResult = bat(script: "git pull --rebase origin ${GITOPS_BRANCH}", returnStatus: true)
+                                    def pullResult = bat(script: "git -c credential.helper= pull --rebase origin ${GITOPS_BRANCH}", returnStatus: true)
                                     if (pullResult != 0) {
                                         echo "First push to ${GITOPS_BRANCH}, no remote branch yet"
                                     }
-                                    bat "git push origin ${GITOPS_BRANCH}"
+                                    bat "git -c credential.helper= push origin ${GITOPS_BRANCH}"
                                 } else {
                                     echo 'No manifest changes detected, skipping commit'
                                 }


### PR DESCRIPTION
## 📌 관련 이슈
> Jenkins 빌드 #14~#26에서 `git push` 시 403 Permission denied 지속 발생

---

## 📝 작업 내용
> Windows Git for Windows에 포함된 Git Credential Manager(GCM)가 URL에 포함된 GitHub 토큰을 무시하고, 캐시된 자격증명(push 권한 없는)을 사용하여 403이 발생하는 문제 수정.

- `git -c credential.helper=` 옵션 추가로 GCM 비활성화
- clone, pull, push 모든 git 명령에 적용
- URL에 포함된 `%GITHUB_TOKEN%`이 직접 인증에 사용되도록 보장

---

## 🔍 변경 사항 유형

- [x] 🐛 버그 수정 (bug fix)

---

## ✅ 셀프 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능이 깨지지 않음 확인
- [x] 불필요한 console.log / 디버그 코드 제거
- [x] 환경변수 / 민감 정보가 코드에 하드코딩되지 않음
- [x] 커밋 메시지가 컨벤션에 맞게 작성됨

---

## 🖥️ 테스트 방법

```bash
# PR 머지 후 Jenkins 빌드 트리거
# Update GitOps Manifest 스테이지에서 git push 성공 확인
# 이전 로그: "Permission denied to fdrn9999" → 수정 후: push 성공
```

---

## 💬 리뷰어에게 전달할 내용

- **근본 원인**: Windows Git for Windows 설치 시 기본 포함되는 GCM이 HTTPS URL의 토큰보다 자체 credential store를 우선 사용
- 로컬 테스트에서 `info: please complete authentication in your browser...` 메시지로 GCM 개입 확인
- `git -c credential.helper=` 는 해당 명령에서만 GCM을 비활성화하므로 다른 git 작업에 영향 없음