### PR TITLE
GitOps 매니페스트를 별도 레포(team2-manifest)로 분리

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ pipeline {
         DOCKER_REGISTRY = 'ckato9173'
         IMAGE_TAG       = "${BUILD_NUMBER}"
         GITHUB_REPO     = 'https://github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git'
+        MANIFEST_REPO   = 'https://github.com/fdrn9999/team2-manifest.git'
         GITOPS_TMP_DIR  = "${WORKSPACE}/gitops-tmp/${BUILD_NUMBER}"
-        GITOPS_BRANCH   = 'gitops/deploy'
     }
 
     triggers {
@@ -138,9 +138,8 @@ pipeline {
             }
         }
 
-        // GitOps: K8s 매니페스트의 이미지 태그를 업데이트하고
-        // gitops/deploy 브랜치에 commit & push하여 ArgoCD가 자동 Sync하도록 위임
-        // main 브랜치는 branch protection(PR+리뷰)이 적용되므로 별도 브랜치 사용
+        // GitOps: 별도 매니페스트 레포(team2-manifest)의 이미지 태그를 업데이트하고
+        // main 브랜치에 commit & push하여 ArgoCD가 자동 Sync하도록 위임
         stage('Update GitOps Manifest') {
             steps {
                 withCredentials([string(
@@ -151,14 +150,12 @@ pipeline {
                         if (isUnix()) {
                             sh """
                                 rm -rf "${GITOPS_TMP_DIR}"
-                                git clone --branch ${GITOPS_BRANCH} https://${GITHUB_TOKEN}@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git "${GITOPS_TMP_DIR}" || \
-                                (git clone https://${GITHUB_TOKEN}@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git "${GITOPS_TMP_DIR}" && \
-                                 cd "${GITOPS_TMP_DIR}" && git checkout -b ${GITOPS_BRANCH})
+                                git clone https://${GITHUB_TOKEN}@github.com/fdrn9999/team2-manifest.git "${GITOPS_TMP_DIR}"
                             """
 
                             sh """
-                                sed -i 's|${DOCKER_REGISTRY}/salesboost-backend:[^ ]*|${DOCKER_REGISTRY}/salesboost-backend:${IMAGE_TAG}|g' "${GITOPS_TMP_DIR}/infra/k8s/deployments/backend.yaml"
-                                sed -i 's|${DOCKER_REGISTRY}/salesboost-frontend:[^ ]*|${DOCKER_REGISTRY}/salesboost-frontend:${IMAGE_TAG}|g' "${GITOPS_TMP_DIR}/infra/k8s/deployments/frontend.yaml"
+                                sed -i 's|${DOCKER_REGISTRY}/salesboost-backend:[^ ]*|${DOCKER_REGISTRY}/salesboost-backend:${IMAGE_TAG}|g' "${GITOPS_TMP_DIR}/deployments/backend.yaml"
+                                sed -i 's|${DOCKER_REGISTRY}/salesboost-frontend:[^ ]*|${DOCKER_REGISTRY}/salesboost-frontend:${IMAGE_TAG}|g' "${GITOPS_TMP_DIR}/deployments/frontend.yaml"
                             """
 
                             // 동시 파이프라인 실행 시 git push 충돌 방지를 위한 재시도 로직
@@ -166,14 +163,14 @@ pipeline {
                                 cd "${GITOPS_TMP_DIR}" && \
                                 git config --local user.email "jenkins@salesboost.ci" && \
                                 git config --local user.name "Jenkins CI" && \
-                                git add infra/k8s/deployments/backend.yaml infra/k8s/deployments/frontend.yaml && \
+                                git add deployments/backend.yaml deployments/frontend.yaml && \
                                 if git diff --cached --quiet; then \
                                     echo "No manifest changes detected, skipping commit"; \
                                 else \
-                                    git commit -m "ci: update image tags to ${IMAGE_TAG} [ci skip]" && \
+                                    git commit -m "ci: update image tags to ${IMAGE_TAG}" && \
                                     for i in 1 2 3; do \
-                                        (git pull --rebase origin ${GITOPS_BRANCH} 2>/dev/null || echo "No remote branch yet, first push") && \
-                                        git push origin ${GITOPS_BRANCH} && break || \
+                                        git pull --rebase origin main && \
+                                        git push origin main && break || \
                                         echo "Push failed (attempt \$i/3), retrying in 5s..." && \
                                         sleep 5; \
                                     done; \
@@ -182,22 +179,14 @@ pipeline {
                         } else {
                             bat "if exist \"${GITOPS_TMP_DIR}\" rmdir /s /q \"${GITOPS_TMP_DIR}\""
 
-                            // gitops/deploy 브랜치가 있으면 clone, 없으면 main에서 새로 생성
+                            // 매니페스트 레포 clone
                             // credential.helper= : Windows GCM이 URL 토큰을 무시하는 것을 방지
-                            script {
-                                def cloneResult = bat(script: "git -c credential.helper= clone --branch ${GITOPS_BRANCH} https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\"", returnStatus: true)
-                                if (cloneResult != 0) {
-                                    bat "git -c credential.helper= clone https://%GITHUB_TOKEN%@github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git \"${GITOPS_TMP_DIR}\""
-                                    dir("${GITOPS_TMP_DIR}") {
-                                        bat "git checkout -b ${GITOPS_BRANCH}"
-                                    }
-                                }
-                            }
+                            bat "git -c credential.helper= clone https://%GITHUB_TOKEN%@github.com/fdrn9999/team2-manifest.git \"${GITOPS_TMP_DIR}\""
 
                             // Windows에서는 PowerShell로 sed 대체
                             powershell """
-                                \$backend = '${GITOPS_TMP_DIR}/infra/k8s/deployments/backend.yaml'
-                                \$frontend = '${GITOPS_TMP_DIR}/infra/k8s/deployments/frontend.yaml'
+                                \$backend = '${GITOPS_TMP_DIR}/deployments/backend.yaml'
+                                \$frontend = '${GITOPS_TMP_DIR}/deployments/frontend.yaml'
                                 (Get-Content \$backend) -replace '${DOCKER_REGISTRY}/salesboost-backend:[^ ]*', '${DOCKER_REGISTRY}/salesboost-backend:${IMAGE_TAG}' | Set-Content \$backend
                                 (Get-Content \$frontend) -replace '${DOCKER_REGISTRY}/salesboost-frontend:[^ ]*', '${DOCKER_REGISTRY}/salesboost-frontend:${IMAGE_TAG}' | Set-Content \$frontend
                             """
@@ -205,16 +194,12 @@ pipeline {
                             dir("${GITOPS_TMP_DIR}") {
                                 bat 'git config --local user.email "jenkins@salesboost.ci"'
                                 bat 'git config --local user.name "Jenkins CI"'
-                                bat 'git add infra/k8s/deployments/backend.yaml infra/k8s/deployments/frontend.yaml'
+                                bat 'git add deployments/backend.yaml deployments/frontend.yaml'
                                 def hasChanges = bat(script: '@git diff --cached --quiet', returnStatus: true)
                                 if (hasChanges != 0) {
-                                    bat "git commit -m \"ci: update image tags to ${IMAGE_TAG} [ci skip]\""
-                                    // pull은 원격 브랜치가 없을 수 있으므로 실패 허용
-                                    def pullResult = bat(script: "git -c credential.helper= pull --rebase origin ${GITOPS_BRANCH}", returnStatus: true)
-                                    if (pullResult != 0) {
-                                        echo "First push to ${GITOPS_BRANCH}, no remote branch yet"
-                                    }
-                                    bat "git -c credential.helper= push origin ${GITOPS_BRANCH}"
+                                    bat "git commit -m \"ci: update image tags to ${IMAGE_TAG}\""
+                                    bat "git -c credential.helper= pull --rebase origin main"
+                                    bat "git -c credential.helper= push origin main"
                                 } else {
                                     echo 'No manifest changes detected, skipping commit'
                                 }
@@ -228,7 +213,7 @@ pipeline {
 
     post {
         success {
-            echo "Pipeline SUCCESS - image tag: ${IMAGE_TAG} pushed to ${GITOPS_BRANCH}. ArgoCD will sync to cluster."
+            echo "Pipeline SUCCESS - image tag: ${IMAGE_TAG} pushed to team2-manifest. ArgoCD will sync to cluster."
             script {
                 if (isUnix()) {
                     sh '''

--- a/infra/k8s/argocd-app.yaml
+++ b/infra/k8s/argocd-app.yaml
@@ -6,12 +6,11 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/20251029-hanhwa-swcamp-22th/be22-4st-team2-project.git
-    targetRevision: gitops/deploy
-    path: infra/k8s
+    repoURL: https://github.com/fdrn9999/team2-manifest.git
+    targetRevision: main
+    path: .
     directory:
       recurse: true
-      exclude: argocd-app.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: default


### PR DESCRIPTION
## 📌 관련 이슈
> 이 PR이 해결하는 이슈를 연결해주세요.

GitOps 아키텍처 개선: 단일 레포 → 멀티 레포 GitOps 전환

---

## 📝 작업 내용
> 이 PR에서 변경된 내용을 간략히 설명해주세요.

기존에 같은 소스 레포의 `gitops/deploy` 브랜치에 매니페스트를 업데이트하던 방식을
별도의 매니페스트 레포(`fdrn9999/team2-manifest`)로 분리합니다.

**변경 포인트:**
- **Jenkinsfile**: `Update GitOps Manifest` 스테이지가 `team2-manifest` 레포를 clone하여 `deployments/*.yaml`의 이미지 태그를 업데이트 후 main에 push
- **argocd-app.yaml**: ArgoCD source를 `team2-manifest` 레포 main 브랜치로 변경
- 별도 레포 사용으로 `[ci skip]` 무한루프 방지 로직이 더 이상 필요 없으므로 커밋 메시지에서 제거
- Windows GCM 우회를 위한 `credential.helper=` 적용

**파이프라인 흐름:**
```
소스 레포 push → Jenkins 트리거 → Build & Test → Docker Build/Push
→ team2-manifest 레포에 이미지 태그 업데이트 push → ArgoCD 자동 Sync
```

---

## 🔍 변경 사항 유형

- [ ] ✨ 새로운 기능 (feature)
- [ ] 🐛 버그 수정 (bug fix)
- [ ] ♻️ 리팩토링 (refactor)
- [x] 🔧 인프라 / 환경 설정 (infra)
- [ ] 📝 문서 수정 (docs)
- [ ] 🎨 UI / 스타일 변경 (style)
- [ ] ✅ 테스트 추가 / 수정 (test)

---

## ✅ 셀프 체크리스트
> 머지 전 본인이 직접 확인해주세요.

- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능이 깨지지 않음 확인
- [x] 불필요한 console.log / 디버그 코드 제거
- [x] 환경변수 / 민감 정보가 코드에 하드코딩되지 않음
- [x] 커밋 메시지가 컨벤션에 맞게 작성됨

---

## 🖥️ 테스트 방법
> 리뷰어가 이 PR을 어떻게 테스트하면 되는지 알려주세요.

1. 매니페스트 레포 확인: https://github.com/fdrn9999/team2-manifest
2. Jenkins 파이프라인 실행 후 `team2-manifest` 레포에 이미지 태그가 업데이트되는지 확인
3. ArgoCD에서 `salesboost` 앱이 `team2-manifest` 레포를 소스로 Sync하는지 확인

```bash
# ArgoCD 앱 재적용
kubectl apply -f infra/k8s/argocd-app.yaml

# ArgoCD에 매니페스트 레포 등록 (필요 시)
argocd repo add https://github.com/fdrn9999/team2-manifest.git

# Sync 상태 확인
argocd app get salesboost
```

---

## 💬 리뷰어에게 전달할 내용
> 리뷰 시 특별히 봐줬으면 하는 부분이나 논의가 필요한 사항이 있다면 작성해주세요.

- Jenkins의 `github-token` credential이 `fdrn9999/team2-manifest` 레포에도 push 권한이 있어야 합니다
- 머지 후 `kubectl apply -f infra/k8s/argocd-app.yaml`로 ArgoCD 앱 설정을 업데이트해야 합니다
- 기존 `gitops/deploy` 브랜치는 더 이상 사용하지 않으므로, 머지 확인 후 삭제해도 됩니다